### PR TITLE
Fixed problem with RHEL7.

### DIFF
--- a/rhel7-server-x86_64.ks
+++ b/rhel7-server-x86_64.ks
@@ -217,7 +217,7 @@ yum clean all --disableplugin=subscription-manager
 
 # clean up installation logs
 rm -rf /var/log/yum.log
-rm -rf /var/lib/yum/* 
+rm -rf /var/lib/yum/*
 rm -rf /root/install.log
 rm -rf /root/install.log.syslog
 rm -rf /root/anaconda-ks.cfg
@@ -275,7 +275,7 @@ yum-utils
 -libertas-sd8787-firmware
 -libertas-usb8388-firmware
 -plymouth
-cloud-init
+###cloud-init
 ###cloud-utils-growpart
 wget
 %end

--- a/rhel7-server-x86_64.tdl
+++ b/rhel7-server-x86_64.tdl
@@ -22,6 +22,13 @@
 #
 echo DHCPV6C=\"yes\" >> /etc/sysconfig/network-scripts/ifcfg-eth0
 
-  </command>
+
+/usr/bin/yum install -y cloud-init --enablerepo=* --disableplugin=subscription-manager || :
+ 
+if [ -e /etc/cloud/cloud.cfg ]; then                                          
+    /bin/sed -i 's|^disable_root: 1|disable_root: 0|' /etc/cloud/cloud.cfg    
+fi                                                                            
+
+   </command>
  </commands>
 </template>


### PR DESCRIPTION
Fixed problem with RHEL7. The oz-install failed with the old configuration.
The problem was that oz could not connect to the guest via ssh, so the process failed.
Moving cloud-init installation from kickstart to the tdl file resolves it.
